### PR TITLE
Added support for QButtonGroup, extended Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,46 @@ config.add_handler('combo', comboBox, mapper=map_dict)
 
 Note how the config is set to `3` (the value of `CHOICE_C`) but displays "Choice C" as text.
 
+Supported Widgets
+-----------------
+The following Qt-Widgets are supported:
+
+ - QComboBox
+ - QCheckBox
+ - QAction
+ - QActionGroup
+ - QPushButton
+ - QSpinBox
+ - QDoubleSpinBox
+ - QPlainTextEdit
+ - QLineEdit
+ - QListWidget
+ - QSlider
+ - QButtonGroup
+ 
+There are also some additional hooks defined for non standard widgets. With
+```python
+import pyqtconfig
+print(pyqtconfig.HOOKS.keys())
+```
+you can obtain a list of all registered Widgets. Adding support for your own widget is also straight forward:
+```python
+from pyqtconfig import ConfigManager
+
+def _get_MyWidget(self):
+    return self.myvalue
+   
+def _set_MyWidget(self, val):
+    self.myvalue = val
+	
+def _event_MyWidget(self):
+    return self.MyValueChanged
+
+config = ConfigManager()
+config.add_hooks('MyWidget', (_get_MyWidget, _set_MyWidget, _event_MyWidget))
+```
+
+
 Saving and loading data
 -----------------------
 

--- a/pyqtconfig/config.py
+++ b/pyqtconfig/config.py
@@ -547,6 +547,29 @@ def _event_QSlider(self):
         Return value change signal for QSlider
     """
     return self.valueChanged
+	
+
+#QButtonGroup
+def _get_QButtonGroup(self):
+    """
+        Get a list of (index, checked) tuples for the buttons in the group
+    """
+    return [(nr, btn.isChecked()) for nr, btn in enumerate(self.buttons())]
+
+
+def _set_QButtonGroup(self, v):
+    """
+        Set the states for all buttons in a group from a list of (index, checked) tuples
+    """
+    for idx, state in v:
+        self.buttons()[idx].setChecked(state)
+
+
+def _event_QButtonGroup(self):
+    """
+        Return button clicked signal for QButtonGroup
+    """
+    return self.buttonClicked
     
     
 
@@ -566,7 +589,8 @@ HOOKS = {
     'QColorButton': (_get_QColorButton, _set_QColorButton, _event_QColorButton),
     'QNoneDoubleSpinBox': (_get_QNoneDoubleSpinBox, _set_QNoneDoubleSpinBox, _event_QNoneDoubleSpinBox),
     'QCheckTreeWidget': (_get_QCheckTreeWidget, _set_QCheckTreeWidget, _event_QCheckTreeWidget),
-    'QSlider': (_get_QSlider, _set_QSlider, _event_QSlider),    
+    'QSlider': (_get_QSlider, _set_QSlider, _event_QSlider),
+    'QButtonGroup': (_get_QButtonGroup, _set_QButtonGroup, _event_QButtonGroup),
 }
 
 


### PR DESCRIPTION
- Added support for QButtonGroup as stated in #4 
- Extended documentation with a list of supported QtWidgets and a short section on about how to register your own widget.
