### PR TITLE
Support Widget inheritance

### DIFF
--- a/pyqtconfig/config.py
+++ b/pyqtconfig/config.py
@@ -149,6 +149,12 @@ except:
         else:
             return s
 
+# Basestring for typechecking
+try:
+    basestring
+except:
+    basestring = str
+
 
 def build_tuple_mapper(mlist):
     '''
@@ -936,7 +942,7 @@ class QSettingsManager(ConfigManagerBase):
                             list: v.toStringList,
                         }
                         v = type_munge[dt]()
-                    elif vt != dt and vt == unicode:
+                    elif vt != dt and vt == basestring:
                         # Value is stored as unicode so munge it
                         type_munge = {
                             int: lambda x: int(x),

--- a/pyqtconfig/config.py
+++ b/pyqtconfig/config.py
@@ -774,7 +774,8 @@ class ConfigManagerBase(QObject):
     # and updated from the config manager. Allows instantaneous updating on config
     # changes and ensuring that elements remain in sync
 
-    def add_handler(self, key, handler, mapper=(lambda x: x, lambda x: x), auto_set_default=True):
+    def add_handler(self, key, handler, mapper=(lambda x: x, lambda x: x),
+                    auto_set_default=True, default=None):
         """
         Add a handler (UI element) for a given config key.
         
@@ -819,7 +820,10 @@ class ConfigManagerBase(QObject):
 
         # If the key is not in defaults, set the default to match the handler
         if key not in self.defaults:
-            self.set_default(key, handler.getter())
+            if default is None:
+                self.set_default(key, handler.getter())
+            else:
+                self.set_default(key, default)
 
         # Keep handler and data consistent
         if self._get(key) is not None:

--- a/pyqtconfig/config.py
+++ b/pyqtconfig/config.py
@@ -3,6 +3,9 @@ from __future__ import unicode_literals
 import logging
 
 # Import PyQt5 classes
+from PyQt5.QtWidgets import QComboBox, QSpinBox, QDoubleSpinBox, QAction, \
+    QActionGroup, QPushButton, QSpinBox, QDoubleSpinBox, QPlainTextEdit, \
+    QLineEdit, QListWidget, QSlider, QButtonGroup
 from .qt import *
 
 import os
@@ -140,8 +143,6 @@ try:
     # Python2.7
     unicode
 except:
-
-
     # Python3 recoding
     def unicode(s):
         if isinstance(s, bytes):
@@ -580,25 +581,19 @@ def _event_QButtonGroup(self):
     
 
 HOOKS = {
-    'QComboBox': (_get_QComboBox, _set_QComboBox, _event_QComboBox),
-    'QCheckBox': (_get_QCheckBox, _set_QCheckBox, _event_QCheckBox),
-    'QAction': (_get_QAction, _set_QAction, _event_QAction),
-    'QActionGroup': (_get_QActionGroup, _set_QActionGroup, _event_QActionGroup),
-    'QPushButton': (_get_QPushButton, _set_QPushButton, _event_QPushButton),
-    'QSpinBox': (_get_QSpinBox, _set_QSpinBox, _event_QSpinBox),
-    'QDoubleSpinBox': (_get_QDoubleSpinBox, _set_QDoubleSpinBox, _event_QDoubleSpinBox),
-    'QPlainTextEdit': (_get_QPlainTextEdit, _set_QPlainTextEdit, _event_QPlainTextEdit),
-    'QLineEdit': (_get_QLineEdit, _set_QLineEdit, _event_QLineEdit),
-    'CodeEditor': (_get_CodeEditor, _set_CodeEditor, _event_CodeEditor),
-    'QListWidget': (_get_QListWidget, _set_QListWidget, _event_QListWidget),
-    'QListWidgetAddRemove': (_get_QListWidgetAddRemove, _set_QListWidgetAddRemove, _event_QListWidgetAddRemove),
-    'QColorButton': (_get_QColorButton, _set_QColorButton, _event_QColorButton),
-    'QNoneDoubleSpinBox': (_get_QNoneDoubleSpinBox, _set_QNoneDoubleSpinBox, _event_QNoneDoubleSpinBox),
-    'QCheckTreeWidget': (_get_QCheckTreeWidget, _set_QCheckTreeWidget, _event_QCheckTreeWidget),
-    'QSlider': (_get_QSlider, _set_QSlider, _event_QSlider),
-    'QButtonGroup': (_get_QButtonGroup, _set_QButtonGroup, _event_QButtonGroup),
+    QComboBox: (_get_QComboBox, _set_QComboBox, _event_QComboBox),
+    QCheckBox: (_get_QCheckBox, _set_QCheckBox, _event_QCheckBox),
+    QAction: (_get_QAction, _set_QAction, _event_QAction),
+    QActionGroup: (_get_QActionGroup, _set_QActionGroup, _event_QActionGroup),
+    QPushButton: (_get_QPushButton, _set_QPushButton, _event_QPushButton),
+    QSpinBox: (_get_QSpinBox, _set_QSpinBox, _event_QSpinBox),
+    QDoubleSpinBox: (_get_QDoubleSpinBox, _set_QDoubleSpinBox, _event_QDoubleSpinBox),
+    QPlainTextEdit: (_get_QPlainTextEdit, _set_QPlainTextEdit, _event_QPlainTextEdit),
+    QLineEdit: (_get_QLineEdit, _set_QLineEdit, _event_QLineEdit),
+    QListWidget: (_get_QListWidget, _set_QListWidget, _event_QListWidget),
+    QSlider: (_get_QSlider, _set_QSlider, _event_QSlider),
+    QButtonGroup: (_get_QButtonGroup, _set_QButtonGroup, _event_QButtonGroup)
 }
-
 
 # ConfigManager handles configuration for a given appview
 # Supports default values, change signals, export/import from file (for workspace saving)
@@ -789,10 +784,10 @@ class ConfigManagerBase(QObject):
 
         """
         # Add map handler for converting displayed values to internal config data
-        if type(mapper) == dict or type(mapper) == OrderedDict:  # By default allow dict types to be used
+        if isinstance(mapper, (dict, OrderedDict)):  # By default allow dict types to be used
             mapper = build_dict_mapper(mapper)
 
-        elif type(mapper) == list and type(mapper[0]) == tuple:
+        elif isinstance(mapper, list) and isinstance(mapper[0], tuple):
             mapper = build_tuple_mapper(mapper)
 
         handler._get_map, handler._set_map = mapper
@@ -802,17 +797,23 @@ class ConfigManagerBase(QObject):
 
         self.handlers[key] = handler
 
-        if type(handler).__name__  not in self.hooks:
-            assert False, "No handler-functions available for this widget type (%s)" % type(handler).__name__
-           
-        hookg, hooks, hooku = self.hooks[type(handler).__name__]
+
+        # Look for class in hooks and add getter, setter, updater
+        iterator = (hooks for (cls, hooks) in self.hooks.items()
+                    if isinstance(handler, cls))
+        try:
+            hookg, hooks, hooku = next(iterator)
+        except StopIteration:
+            raise TypeError("No handler-functions available for this widget "
+                            "type (%s)" % type(handler).__name__)
 
         handler.getter = types_MethodType(hookg, handler)
         handler.setter = types_MethodType(hooks, handler)
         handler.updater = types_MethodType(hooku, handler)
 
         logging.debug("Add handler %s for %s" % (type(handler).__name__, key))
-        handler_callback = lambda x = None: self.set(key, handler.getter(), trigger_handler=False)
+        handler_callback = lambda x = None: self.set(key, handler.getter(),
+                                                     trigger_handler=False)
         handler.updater().connect(handler_callback)
 
         # Store this so we can issue a specific remove on deletes

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+"""
+    Copyright © 2015 by Stefan Lehmann
+
+"""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,46 @@
+"""
+    test_config.py Copyright © 2015 by Stefan Lehmann
+
+    Test assignment of hooks.
+
+"""
+import sys
+import pytest
+
+from PyQt5.QtWidgets import QLineEdit, QApplication
+from pyqtconfig import ConfigManager
+from pyqtconfig.config import _get_QLineEdit, _set_QLineEdit, _event_QLineEdit
+
+app = QApplication(sys.argv)
+
+
+def test_hook_direct():
+    widget = QLineEdit()
+    config = ConfigManager()
+    assert config._get_hook(widget) == QLineEdit
+
+def test_hook_inherited():
+    class MyLineEdit(QLineEdit):
+        pass
+
+    widget = MyLineEdit()
+    config = ConfigManager()
+    assert config._get_hook(widget) == QLineEdit
+
+def test_hook_inherited_direct():
+    class MyLineEdit(QLineEdit):
+        pass
+
+    widget = MyLineEdit()
+    config = ConfigManager()
+    config.add_hooks(MyLineEdit, (_get_QLineEdit, _set_QLineEdit, _event_QLineEdit))
+    assert config._get_hook(widget) == MyLineEdit
+
+def test_no_hook():
+    class MyTestClass:
+        pass
+    o = MyTestClass()
+    config = ConfigManager()
+    with pytest.raises(TypeError) as e:
+        assert config._get_hook(o)
+    assert "No handler-functions available for this" in str(e)


### PR DESCRIPTION
I tried to solve #8, #12  by not using `type == str` but `isinstance(obj, type)` as criteria. So I had to rewrite the HOOKS dictionary by using the type as keys. I' m not sure how this will work out in case an inherited Widget is also included in the HOOKS. I guess this needs some testing.
