### PR TITLE
Check if QVariant is available in config.py

### DIFF
--- a/pyqtconfig/config.py
+++ b/pyqtconfig/config.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     import xml.etree.ElementTree as et
 
+try:
+    QVariant
+except NameError:
+    QVariant = None
+            
 RECALCULATE_ALL = 1
 RECALCULATE_VIEW = 2
 


### PR DESCRIPTION
As PySide doesn' t support `QVariant` I get an Error in line 941. My approach here is to check if `QVariant` has been imported (PyQt). Otherwise (PySide) `QVariant` is set to `None`.
