### PR TITLE
use Qt4 QString with api version 1 if required 

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,8 +29,11 @@ test:
 about:
   home: https://github.com/mfitzp/pyqtconfig
   license: BSD License
-  summary: 'An API for keeping PyQt widgets in sync with a config dictionary or QSettings object.',
-
+  summary: 'An API for keeping PyQT widgets in sync with a config dictionary or QSettings objects'
+#about:
+#  home: https://github.com/mfitzp/pyqtconfig
+#  license: BSD License
+#  summary: 'An API for keeping PyQt widgets in sync with a config dictionary or QSettings object.'
 # See
 # http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.10"
+  version: "0.8.11"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.10
+  git_rev: 0.8.11
   git_url: https://github.com/mjirik/pyqtconfig.git
 
   # this is used for pypi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.9"
+  version: "0.8.10"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.9
+  git_rev: 0.8.10
   git_url: https://github.com/mjirik/pyqtconfig.git
 
   # this is used for pypi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.18"
+  version: "0.8.19"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.18
+  git_rev: 0.8.19
   git_url: https://github.com/mjirik/pyqtconfig.git
 
   # build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,10 +23,10 @@ source:
     # syntax is module:function.  For example
     #
     # - scaffan = scaffan:main
-build:
+# build:
   # noarch_python: True
   # preserve_egg_dir: True
-  entry_points:
+  # entry_points:
     # Put any entry points (scripts to be generated automatically) here. The
     # syntax is module:function.  For example
     #

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.16"
+  version: "0.8.17"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.16
+  git_rev: 0.8.17
   git_url: https://github.com/mjirik/pyqtconfig.git
 
 build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,74 @@
+package:
+  name: pyqtconfig
+  version: "0.8.8"
+
+source:
+# this is used for build from git hub
+  git_rev: 0.8.8
+  git_url: https://github.com/mjirik/scaffan.git
+
+# this is used for pypi
+  # fn: io3d-1.0.30.tar.gz
+  # url: https://pypi.python.org/packages/source/i/io3d/io3d-1.0.30.tar.gz
+  # md5: a3ce512c4c97ac2410e6dcc96a801bd8
+#  patches:
+   # List any patch files here
+   # - fix.patch
+build:
+  ignore_prefix_files:
+    - devel
+    - examples
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - scaffan = scaffan:main
+    #
+    # Would create an entry point called io3d that calls scaffan.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+#    - io3d
+
+  run:
+    - python
+#    - io3d>=1.21
+#    - {{ pin_compatible('io3d', max_pin='x') }}
+    # - numpy
+    # - pyqt 4.11.*
+
+test:
+  # Python imports
+  imports:
+    - pyqtconfig
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/mfitzp/pyqtconfig
+  license: BSD License
+  summary: 'An API for keeping PyQt widgets in sync with a config dictionary or QSettings object.',
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,10 +24,10 @@ requirements:
   run:
     - python
     - pyqt
+
 test:
   imports:
     - pyqtconfig
-
   # commands:
     # You can put test commands to be run here.  Use this to test that the
     # entry points work.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.13"
+  version: "0.8.14"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.13
+  git_rev: 0.8.14
   git_url: https://github.com/mjirik/pyqtconfig.git
 
 requirements:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,17 +9,21 @@ source:
 
 build:
   noarch_python: True
-  ignore_prefix_files:
-    - devel
-    - examples
+#  ignore_prefix_files:
+#    - devel
+#    - examples
 
 requirements:
   build:
     - python
     - setuptools
+    - numpy
+    - scipy
     - pyqt
   run:
     - python
+    - numpy
+    - scipy
     - setuptools
     - pyqt
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
 # this is used for build from git hub
   git_rev: 0.8.8
-  git_url: https://github.com/mjirik/scaffan.git
+  git_url: https://github.com/mjirik/pyqtconfig.git
 
 # this is used for pypi
   # fn: io3d-1.0.30.tar.gz
@@ -29,10 +29,6 @@ build:
     #
     # Would create an entry point called io3d that calls scaffan.main()
 
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
 
 requirements:
   build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.15"
+  version: "0.8.16"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.15
+  git_rev: 0.8.16
   git_url: https://github.com/mjirik/pyqtconfig.git
 
 build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.12"
+  version: "0.8.13"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.12
+  git_rev: 0.8.13
   git_url: https://github.com/mjirik/pyqtconfig.git
 
   # this is used for pypi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_rev: 0.8.8
   git_url: https://github.com/mjirik/pyqtconfig.git
 
-# this is used for pypi
+  # this is used for pypi
   # fn: io3d-1.0.30.tar.gz
   # url: https://pypi.python.org/packages/source/i/io3d/io3d-1.0.30.tar.gz
   # md5: a3ce512c4c97ac2410e6dcc96a801bd8
@@ -23,7 +23,7 @@ source:
     # syntax is module:function.  For example
     #
     # - scaffan = scaffan:main
-  
+
 requirements:
   build:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -11,28 +11,6 @@ source:
   # fn: io3d-1.0.30.tar.gz
   # url: https://pypi.python.org/packages/source/i/io3d/io3d-1.0.30.tar.gz
   # md5: a3ce512c4c97ac2410e6dcc96a801bd8
-#build:
-#  ignore_prefix_files:
-#    - devel
-#    - examples
-# build:
-  # noarch_python: True
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - scaffan = scaffan:main
-# build:
-  # noarch_python: True
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    #    - lisa = lisa:main
-#    - lisa = lisa:lisa_main
-
 requirements:
   build:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.19"
+  version: "0.8.20"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.19
+  git_rev: 0.8.20
   git_url: https://github.com/mjirik/pyqtconfig.git
 
   # build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.8"
+  version: "0.8.9"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.8
+  git_rev: 0.8.9
   git_url: https://github.com/mjirik/pyqtconfig.git
 
   # this is used for pypi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.11"
+  version: "0.8.12"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.11
+  git_rev: 0.8.12
   git_url: https://github.com/mjirik/pyqtconfig.git
 
   # this is used for pypi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.17"
+  version: "0.8.18"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.17
+  git_rev: 0.8.18
   git_url: https://github.com/mjirik/pyqtconfig.git
 
 build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -7,16 +7,11 @@ source:
   git_rev: 0.8.13
   git_url: https://github.com/mjirik/pyqtconfig.git
 
-  # this is used for pypi
-  # fn: io3d-1.0.30.tar.gz
-  # url: https://pypi.python.org/packages/source/i/io3d/io3d-1.0.30.tar.gz
-  # md5: a3ce512c4c97ac2410e6dcc96a801bd8
 requirements:
   build:
     - python
     - setuptools
     - pyqt
-#    #    - {{ pin_compatible('io3d', max_pin='x') }}
   run:
     - python
     - pyqt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,11 +16,7 @@ requirements:
     - python
     - setuptools
     - pyqt
-#    - io3d
-#    #    - io3d>=1.21
 #    #    - {{ pin_compatible('io3d', max_pin='x') }}
-#    # - numpy
-#    # - pyqt 4.11.*
   run:
     - python
     - pyqt
@@ -28,18 +24,6 @@ requirements:
 test:
   imports:
     - pyqtconfig
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
-
 about:
   home: https://github.com/mfitzp/pyqtconfig
   license: BSD License

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,6 +23,15 @@ source:
     # syntax is module:function.  For example
     #
     # - scaffan = scaffan:main
+build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    #    - lisa = lisa:main
+#    - lisa = lisa:lisa_main
 
 requirements:
   build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.14"
+  version: "0.8.15"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.14
+  git_rev: 0.8.15
   git_url: https://github.com/mjirik/pyqtconfig.git
 
 build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyqtconfig
-  version: "0.8.20"
+  version: "0.8.21"
 
 source:
 # this is used for build from git hub
-  git_rev: 0.8.20
+  git_rev: 0.8.21
   git_url: https://github.com/mjirik/pyqtconfig.git
 
   # build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,8 +26,6 @@ build:
     # syntax is module:function.  For example
     #
     # - scaffan = scaffan:main
-    #
-    # Would create an entry point called io3d that calls scaffan.main()
 requirements:
   build:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,9 +24,7 @@ requirements:
   run:
     - python
     - pyqt
-
 test:
-  # Python imports
   imports:
     - pyqtconfig
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ source:
     # syntax is module:function.  For example
     #
     # - scaffan = scaffan:main
+  
 requirements:
   build:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,14 +28,11 @@ build:
     # - scaffan = scaffan:main
     #
     # Would create an entry point called io3d that calls scaffan.main()
-
-
 requirements:
   build:
     - python
     - setuptools
 #    - io3d
-
   run:
     - python
 #    - io3d>=1.21

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -7,8 +7,8 @@ source:
   git_rev: 0.8.17
   git_url: https://github.com/mjirik/pyqtconfig.git
 
-build:
-  noarch_python: True
+  # build:
+  # noarch_python: True
 #  ignore_prefix_files:
 #    - devel
 #    - examples

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -7,6 +7,12 @@ source:
   git_rev: 0.8.14
   git_url: https://github.com/mjirik/pyqtconfig.git
 
+build:
+  noarch_python: True
+  ignore_prefix_files:
+    - devel
+    - examples
+
 requirements:
   build:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -11,13 +11,10 @@ source:
   # fn: io3d-1.0.30.tar.gz
   # url: https://pypi.python.org/packages/source/i/io3d/io3d-1.0.30.tar.gz
   # md5: a3ce512c4c97ac2410e6dcc96a801bd8
-#  patches:
-   # List any patch files here
-   # - fix.patch
-build:
-  ignore_prefix_files:
-    - devel
-    - examples
+#build:
+#  ignore_prefix_files:
+#    - devel
+#    - examples
 # build:
   # noarch_python: True
   # preserve_egg_dir: True

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - python
     - numpy
     - scipy
-    - setuptools
     - pyqt
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,13 +15,15 @@ requirements:
   build:
     - python
     - setuptools
+    - pyqt
 #    - io3d
+#    #    - io3d>=1.21
+#    #    - {{ pin_compatible('io3d', max_pin='x') }}
+#    # - numpy
+#    # - pyqt 4.11.*
   run:
     - python
-#    - io3d>=1.21
-#    - {{ pin_compatible('io3d', max_pin='x') }}
-    # - numpy
-    # - pyqt 4.11.*
+    - pyqt
 
 test:
   # Python imports

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pyqt
   run:
     - python
+    - setuptools
     - pyqt
 
 test:

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.15"
+__version__ = "0.8.16"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,1 +1,2 @@
 from .config import *
+__version__ = "0.8.8"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.8"
+__version__ = "0.8.9"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.17"
+__version__ = "0.8.18"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.18"
+__version__ = "0.8.19"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.10"
+__version__ = "0.8.11"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.20"
+__version__ = "0.8.21"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.13"
+__version__ = "0.8.14"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.11"
+__version__ = "0.8.12"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.19"
+__version__ = "0.8.20"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.16"
+__version__ = "0.8.17"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.9"
+__version__ = "0.8.10"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.14"
+__version__ = "0.8.15"

--- a/pyqtconfig/__init__.py
+++ b/pyqtconfig/__init__.py
@@ -1,2 +1,2 @@
 from .config import *
-__version__ = "0.8.12"
+__version__ = "0.8.13"

--- a/pyqtconfig/qt.py
+++ b/pyqtconfig/qt.py
@@ -56,8 +56,12 @@ elif USE_QT_PY == PYSIDE:
 
 elif USE_QT_PY == PYQT4:
     import sip
-    sip.setapi('QString', 2)
-    sip.setapi('QVariant', 2)
+    try:
+        sip.setapi('QString', 2)
+        sip.setapi('QVariant', 2)
+    except:
+        print "Using QVariant and QString version 1"
+        pass
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
     from PyQt4.QtWebKit import *

--- a/pyqtconfig/qt.py
+++ b/pyqtconfig/qt.py
@@ -44,7 +44,10 @@ if USE_QT_PY == PYQT5:
     from PyQt5.QtWebKit import *
     from PyQt5.QtNetwork import *
     from PyQt5.QtWidgets import *
-    from PyQt5.QtWebKitWidgets import *
+    try:
+        from PyQt5.QtWebKitWidgets import *
+    except:
+        from PyQt5.QtWebEngine import *
 
 elif USE_QT_PY == PYSIDE:
     from PySide.QtGui import *

--- a/pyqtconfig/qt.py
+++ b/pyqtconfig/qt.py
@@ -41,13 +41,17 @@ else:
 if USE_QT_PY == PYQT5:
     from PyQt5.QtGui import *
     from PyQt5.QtCore import *
-    from PyQt5.QtWebKit import *
+    try:
+        from PyQt5.QtWebKit import *
+    except:
+        from PyQt5.QtWebEngine import *
+
     from PyQt5.QtNetwork import *
     from PyQt5.QtWidgets import *
     try:
         from PyQt5.QtWebKitWidgets import *
     except:
-        from PyQt5.QtWebEngine import *
+        pass
 
 elif USE_QT_PY == PYSIDE:
     from PySide.QtGui import *

--- a/pyqtconfig/qt.py
+++ b/pyqtconfig/qt.py
@@ -60,7 +60,7 @@ elif USE_QT_PY == PYQT4:
         sip.setapi('QString', 2)
         sip.setapi('QVariant', 2)
     except:
-        print "Using QVariant and QString version 1"
+        print("Using QVariant and QString version 1")
         pass
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.16
+current_version = 0.8.17
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.8
+current_version = 0.8.9
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.20
+current_version = 0.8.21
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.11
+current_version = 0.8.12
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.10
+current_version = 0.8.11
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.9
+current_version = 0.8.10
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[bumpversion]
+current_version = 0.8.8
+files = setup.py conda-recipe/meta.yaml scaffan/__init__.py
+commit = True
+tag = True
+tag_name = {new_version}
+
+[nosetests]
+attr = !interactive,!slow,!LAR
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.15
+current_version = 0.8.16
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.19
+current_version = 0.8.20
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.18
+current_version = 0.8.19
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 0.8.8
-files = setup.py conda-recipe/meta.yaml scaffan/__init__.py
+files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.14
+current_version = 0.8.15
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.17
+current_version = 0.8.18
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.12
+current_version = 0.8.13
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.13
+current_version = 0.8.14
 files = setup.py conda-recipe/meta.yaml pyqtconfig/__init__.py
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.7",
+    version="0.8.8",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.6",
+    version="0.8.7",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.18",
+    version="0.8.19",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.12",
+    version="0.8.13",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.9",
+    version="0.8.10",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.17",
+    version="0.8.18",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.13",
+    version="0.8.14",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.15",
+    version="0.8.16",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.8",
+    version="0.8.9",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.19",
+    version="0.8.20",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.14",
+    version="0.8.15",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.11",
+    version="0.8.12",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.20",
+    version="0.8.21",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.16",
+    version="0.8.17",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(
 
     name='pyqtconfig',
-    version="0.8.10",
+    version="0.8.11",
     author='Martin Fitzpatrick',
     author_email='martin.fitzpatrick@gmail.com',
     url='https://github.com/mfitzp/pyqtconfig',


### PR DESCRIPTION
it is usefull if another imported module (like matplotlib) uses pyqt with api version 1
